### PR TITLE
[CoPP] Add always_enabled field to copp_cfg.j2 and yang model

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -13,7 +13,7 @@
 		    "trap_priority":"4",
 		    "queue": "4"
 	    },
-	    "queue4_group2": {            
+	    "queue4_group2": {
 		    "trap_action":"copy",
 		    "trap_priority":"4",
 		    "queue": "4",
@@ -69,11 +69,13 @@
 	    },
 	    "lacp": {
 		    "trap_ids": "lacp",
-		    "trap_group": "queue4_group1"
+		    "trap_group": "queue4_group1",
+		    "always_enabled": "true"
 	    },
 	    "arp": {
 		    "trap_ids": "arp_req,arp_resp,neigh_discovery",
-		    "trap_group": "queue4_group2"
+		    "trap_group": "queue4_group2",
+		    "always_enabled": "true"
 	    },
 	    "lldp": {
 		    "trap_ids": "lldp",
@@ -85,11 +87,13 @@
 	    },
 	    "udld": {
 		    "trap_ids": "udld",
-		    "trap_group": "queue4_group3"
+		    "trap_group": "queue4_group3",
+		    "always_enabled": "true"
 	    },
 	    "ip2me": {
 		    "trap_ids": "ip2me",
-		    "trap_group": "queue1_group1"
+		    "trap_group": "queue1_group1",
+		    "always_enabled": "true"
 	    },
 	    "nat": {
 		    "trap_ids": "src_nat_miss,dest_nat_miss",

--- a/platform/vs/docker-sonic-vs/init_cfg.json.j2
+++ b/platform/vs/docker-sonic-vs/init_cfg.json.j2
@@ -5,7 +5,7 @@
             "buffer_model": "traditional"
         }
     },
-{% set features = ["swss", "bgp", "teamd", "nat", "database"] %}
+{% set features = ["swss", "bgp", "teamd", "nat", "database", "lldp", "dhcp_relay", "macsec"] %}
     "FEATURE": {
 {% for feature in features %}
         "{{ feature }}": {

--- a/src/sonic-yang-models/yang-models/sonic-copp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-copp.yang
@@ -163,6 +163,11 @@ module sonic-copp {
 					}
 					description "reference to CoPP group";
 				}
+				
+				leaf always_enabled {
+					type boolean;
+					description "field that indicates whether the trap should be always installed";
+				}
 			}
 			/* end of list COPP_TRAP_LIST */
 		}

--- a/src/sonic-yang-models/yang-models/sonic-copp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-copp.yang
@@ -43,13 +43,13 @@ module sonic-copp {
 					type stypes:copp_packet_action;
 					description "Trap action";
 				}
-				
+
 				leaf meter_type {
 					mandatory true;
 					type stypes:meter_type;
 					description "Policer meter type";
 				}
-				
+
 				leaf mode {
 					mandatory true;
 					type enumeration {
@@ -59,7 +59,7 @@ module sonic-copp {
 					}
 					description "Policer mode";
 				}
-				
+
 				leaf color {
 					type enumeration {
 						enum blind;
@@ -74,7 +74,7 @@ module sonic-copp {
 					default 0;
 					description
 						"Committed information rate for the dual-rate token
-						bucket policer.  This value represents the rate at which 
+						bucket policer.  This value represents the rate at which
 						tokens are added to the primary bucket.";
 				}
 
@@ -118,13 +118,13 @@ module sonic-copp {
 						"Excess burst size for the dual-rate token bucket policer.
 						This value represents the depth of the secondary bucket.";
 				}
-				
+
 				leaf green_action {
 					type stypes:copp_packet_action;
 					default "forward";
 					description "Green action";
 				}
-				
+
 				leaf yellow_action {
 					when "((current()/../mode = 'sr_tcm') or (current()/../mode = 'tr_tcm'))";
 					type stypes:copp_packet_action;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add the "always_enabled" field to copp_cfg.j2 file, in order to allow traps without an entry in features table, to be installed automatically.

#### How I did it
Add the new field, and changed the logic in sonic-swss as well.
#### How to verify it
Check that arp, udld, ip2me and lacp traps are auto installed, and traps that has no feature entry are not auto installed.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

