### PR TITLE
[Mellanox] Support running hw-management service on SN5640 emulation platform

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5640_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5640_simx-r0/pmon_daemon_control.json
@@ -1,7 +1,5 @@
 {
         "skip_ledd": true,
         "skip_xcvrd": true,
-        "skip_psud": true,
-        "skip_pcied": true,
-        "skip_thermalctld": true
+        "skip_fancontrol": true
 }

--- a/device/mellanox/x86_64-nvidia_sn5640_simx-r0/thermal_policy.json
+++ b/device/mellanox/x86_64-nvidia_sn5640_simx-r0/thermal_policy.json
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/thermal_policy.json

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -160,6 +160,13 @@ DEVICE_DATA = {
         },
         'sfp': {
             'fw_control_ports': [64]  # 0 based sfp index list
+        }
+    },
+    'x86_64-nvidia_sn5640_simx-r0': {
+        'thermal': {
+            "capability": {
+                "comex_amb": False,
+            }
         }
     },
     'x86_64-nvidia_sn4280_simx-r0': {

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +42,7 @@ logger = Logger()
 #
 EEPROM_SYMLINK = "/var/run/hw-management/eeprom/vpd_info"
 platform_name = DeviceDataManager.get_platform_name()
-platform_supporting_simx = ['x86_64-nvidia_sn4280_simx-r0', 'x86_64-mlnx_msn4700_simx-r0']
+platform_supporting_simx = ['x86_64-nvidia_sn4280_simx-r0', 'x86_64-mlnx_msn4700_simx-r0', 'x86_64-mlnx_msn5640_simx-r0']
 if platform_name and 'simx' in platform_name and not platform_name in platform_supporting_simx:
     if not os.path.exists(EEPROM_SYMLINK):
         if is_host():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support running hw-management service on SN5640 emulation platform.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Use physical EEPROM instead of the fake one
- Do not skip PSUd, PCId, thermal control daemon
- Adjust PCIe and thermal configuration files

#### How to verify it
Run Nvidia simulation on SN5640 (ASIC and Platform)


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

