### PR TITLE
[Mellanox] Update SN5640 platform to run as chipless

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/pmon_daemon_control.json
@@ -1,6 +1,0 @@
-{
-    "skip_ledd": true,
-    "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": false
-}
-

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/pmon_daemon_control.json
@@ -1,6 +1,0 @@
-{
-    "skip_ledd": true,
-    "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": false
-}
-

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/platform_wait
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/platform_wait
@@ -1,1 +1,26 @@
-../x86_64-mlnx_msn2700-r0/platform_wait
+#!/usr/bin/python3
+
+#
+# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+from sonic_platform.device_data import DeviceDataManager
+from sonic_py_common.logger import Logger
+
+logger = Logger(log_identifier='platform_wait')
+logger.log_notice('Nvidia: Set True for PMON dependencies ready')
+sys.exit(0)

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/pmon_daemon_control.json
@@ -1,6 +1,6 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": true
+    "skip_xcvrd": true
 }
 

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -64,10 +64,10 @@
 {%- set features = [("bgp", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}", false, "enabled"),
                    ("database", "always_enabled", false, "always_enabled"),
                    ("lldp", "enabled", true, "enabled"),
-                   ("pmon", "enabled", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' %}False{% else %}True{% endif %}", "enabled"),
+                   ("pmon", "enabled", false, "enabled"),
                    ("snmp", "enabled", true, "enabled"),
-                   ("swss", "enabled", false, "enabled"),
-                   ("syncd", "enabled", false, "enabled")] %}
+                   ("swss", "disabled", false, "disabled"),
+                   ("syncd", "disabled", false, "disabled")] %}
 {%- if include_router_advertiser == "y" %}{% do features.append(("radv", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_teamd == "y" %}{% do features.append(("teamd", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] %}disabled{% else %}enabled{% endif %}", false, "enabled")) %}{% endif %}
 {% do features.append(("dhcp_relay", "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] is not in ['ToRRouter', 'EPMS', 'MgmtTsToR', 'MgmtToRRouter', 'BmcMgmtToRRouter']) %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}

--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -3,7 +3,7 @@ Description=Platform monitor container
 Requires=database.service config-setup.service
 After=database.service config-setup.service
 {% if sonic_asic_platform == 'mellanox' %}
-After=syncd.service
+#After=syncd.service
 {% endif %}
 BindsTo=sonic.target
 After=sonic.target


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To be able to run SN5640 Mellanox chipless system
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Update platform_wait for SN5640 to start pmon without waiting

- Remove requirement for pmon to start after syncd

- Disable only syncd and swss features

- Set pmon delay to false, so pmon will not wait for port init

- Disable xcvrd process inside PMON

#### How to verify it
Run image on SN5640 Mellanox chipless system
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

