### PR TITLE
[Mellanox] Update sensors.conf of SN5610N, SN5640 platforms

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5610n-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn5610n-r0/sensors.conf
@@ -1,8 +1,12 @@
 ##################################################################################
-# Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Platform specific sensors config for SN5640
 ##################################################################################
+
+# ASIC temperature sensor
+chip "mlxsw-i2c-*-48"
+    label temp1 "Ambient ASIC Temp"
 
 # Fan and port ambient temperature sensors
 chip "tmp102-i2c-*-49"
@@ -382,7 +386,7 @@ chip "xdpe1a2g7-i2c-*-6e"
 chip "dps460-i2c-*-59"
     label in1 "PSU-1(L) 220V Rail (in)"
     ignore in2
-    label in3 "PSU-1(L) 54V Rail (out)"
+    label in3 "PSU-1(L) 12V Rail (out)"
     ignore fan2
     ignore fan3
     label fan1 "PSU-1(L) Fan 1"
@@ -390,29 +394,29 @@ chip "dps460-i2c-*-59"
     label temp2 "PSU-1(L) Temp 2"
     label temp3 "PSU-1(L) Temp 3"
     label power1 "PSU-1(L) 220V Rail Pwr (in)"
-    label power2 "PSU-1(L) 54V Rail Pwr (out)"
+    label power2 "PSU-1(L) 12V Rail Pwr (out)"
     label curr1 "PSU-1(L) 220V Rail Curr (in)"
-    label curr2 "PSU-1(L) 54V Rail Curr (out)"
+    label curr2 "PSU-1(L) 12V Rail Curr (out)"
     set power2_cap 0
 chip "dps460-i2c-*-58"
-    label in1 "PSU-2(R) 220V Rail (in)"
+    label in1 "PSU-2(L) 220V Rail (in)"
     ignore in2
-    label in3 "PSU-2(R) 54V Rail (out)"
+    label in3 "PSU-2(L) 12V Rail (out)"
     ignore fan2
     ignore fan3
-    label fan1 "PSU-2(R) Fan 1"
-    label temp1 "PSU-2(R) Temp 1"
-    label temp2 "PSU-2(R) Temp 2"
-    label temp3 "PSU-2(R) Temp 3"
-    label power1 "PSU-2(R) 220V Rail Pwr (in)"
-    label power2 "PSU-2(R) 54V Rail Pwr (out)"
-    label curr1 "PSU-2(R) 220V Rail Curr (in)"
-    label curr2 "PSU-2(R) 54V Rail Curr (out)"
+    label fan1 "PSU-2(L) Fan 1"
+    label temp1 "PSU-2(L) Temp 1"
+    label temp2 "PSU-2(L) Temp 2"
+    label temp3 "PSU-2(L) Temp 3"
+    label power1 "PSU-2(L) 220V Rail Pwr (in)"
+    label power2 "PSU-2(L) 12V Rail Pwr (out)"
+    label curr1 "PSU-2(L) 220V Rail Curr (in)"
+    label curr2 "PSU-2(L) 12V Rail Curr (out)"
     set power2_cap 0
 chip "dps460-i2c-*-5b"
     label in1 "PSU-3(R) 220V Rail (in)"
     ignore in2
-    label in3 "PSU-3(R) 54V Rail (out)"
+    label in3 "PSU-3(R) 12V Rail (out)"
     ignore fan2
     ignore fan3
     label fan1 "PSU-3(R) Fan 1"
@@ -420,14 +424,14 @@ chip "dps460-i2c-*-5b"
     label temp2 "PSU-3(R) Temp 2"
     label temp3 "PSU-3(R) Temp 3"
     label power1 "PSU-3(R) 220V Rail Pwr (in)"
-    label power2 "PSU-3(R) 54V Rail Pwr (out)"
+    label power2 "PSU-3(R) 12V Rail Pwr (out)"
     label curr1 "PSU-3(R) 220V Rail Curr (in)"
-    label curr2 "PSU-3(R) 54V Rail Curr (out)"
+    label curr2 "PSU-3(R) 12V Rail Curr (out)"
     set power2_cap 0
 chip "dps460-i2c-*-5a"
     label in1 "PSU-4(R) 220V Rail (in)"
     ignore in2
-    label in3 "PSU-4(R) 54V Rail (out)"
+    label in3 "PSU-4(R) 12V Rail (out)"
     ignore fan2
     ignore fan3
     label fan1 "PSU-4(R) Fan 1"
@@ -435,10 +439,23 @@ chip "dps460-i2c-*-5a"
     label temp2 "PSU-4(R) Temp 2"
     label temp3 "PSU-4(R) Temp 3"
     label power1 "PSU-4(R) 220V Rail Pwr (in)"
-    label power2 "PSU-4(R) 54V Rail Pwr (out)"
+    label power2 "PSU-4(R) 12V Rail Pwr (out)"
     label curr1 "PSU-4(R) 220V Rail Curr (in)"
-    label curr2 "PSU-4(R) 54V Rail Curr (out)"
+    label curr2 "PSU-4(R) 12V Rail Curr (out)"
     set power2_cap 0
+
+# Chassis fans
+chip "mlxreg_fan-isa-*"
+    label fan1 "Chassis Fan Drawer-1 Tach 1"
+    label fan2 "Chassis Fan Drawer-1 Tach 2"
+    label fan3 "Chassis Fan Drawer-2 Tach 1"
+    label fan4 "Chassis Fan Drawer-2 Tach 2"
+    label fan5 "Chassis Fan Drawer-3 Tach 1"
+    label fan6 "Chassis Fan Drawer-3 Tach 2"
+    label fan7 "Chassis Fan Drawer-4 Tach 1"
+    label fan8 "Chassis Fan Drawer-4 Tach 2"
+    label fan9 "Chassis Fan Drawer-5 Tach 1"
+    label fan10 "Chassis Fan Drawer-5 Tach 2"
 
 # AMD Comex Power controllers
 chip "mp2855-i2c-*-69"
@@ -486,5 +503,5 @@ chip "nvme-pci-*"
     ignore temp3
 
 # Ethernet PHY temperature sensor
-chip "00000500400-mdio-5"
-   label temp1 "PHY TEMP"
+chip "*-mdio-*"
+   ignore temp1

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/sensors.conf
@@ -1,5 +1,5 @@
 ##################################################################################
-# Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Platform specific sensors config for SN5640
 ##################################################################################
@@ -406,7 +406,7 @@ chip "dps460-i2c-*-58"
     ignore fan3
     label fan1 "PSU-2(L) Fan 1"
     label temp1 "PSU-2(L) Temp 1"
-    label temp2 "PSU-2(R) Temp 2"
+    label temp2 "PSU-2(L) Temp 2"
     label temp3 "PSU-2(L) Temp 3"
     label power1 "PSU-2(L) 220V Rail Pwr (in)"
     label power2 "PSU-2(L) 12V Rail Pwr (out)"
@@ -443,6 +443,19 @@ chip "dps460-i2c-*-5a"
     label curr1 "PSU-4(R) 220V Rail Curr (in)"
     label curr2 "PSU-4(R) 12V Rail Curr (out)"
     set power2_cap 0
+
+# Chassis fans
+chip "mlxreg_fan-isa-*"
+    label fan1 "Chassis Fan Drawer-1 Tach 1"
+    label fan2 "Chassis Fan Drawer-1 Tach 2"
+    label fan3 "Chassis Fan Drawer-2 Tach 1"
+    label fan4 "Chassis Fan Drawer-2 Tach 2"
+    label fan5 "Chassis Fan Drawer-3 Tach 1"
+    label fan6 "Chassis Fan Drawer-3 Tach 2"
+    label fan7 "Chassis Fan Drawer-4 Tach 1"
+    label fan8 "Chassis Fan Drawer-4 Tach 2"
+    label fan9 "Chassis Fan Drawer-5 Tach 1"
+    label fan10 "Chassis Fan Drawer-5 Tach 2"
 
 # AMD Comex Power controllers
 chip "mp2855-i2c-*-69"
@@ -490,5 +503,5 @@ chip "nvme-pci-*"
     ignore temp3
 
 # Ethernet PHY temperature sensor
-chip "00000400400-mdio-4"
-   label temp1 "Eth Phy Temp"
+chip "*-mdio-*"
+   ignore temp1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To have the updated sensors.conf for SN5610N and SN5640 Mellanox platforms

#### How I did it
Took the last updated file 

#### How to verify it
Run platform test
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

