### PR TITLE
[Mellanox] Add a query in MDF to make copper-active modules be FW control

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -1061,6 +1061,9 @@ class SFP(NvidiaSFPCommon):
             bool: True if the api object supports software control
         """
         if xcvr_api.is_flat_memory():
+            # For Copper active modules, Nvidia doesn't support SW control
+            if xcvr_api.get_media_interface_technology() == 'Copper cable, linear active equalizers':
+                return False
             return self.is_cmis_api(xcvr_api) or self.is_sff_api(xcvr_api)
         else:
             return self.is_cmis_api(xcvr_api)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -188,6 +188,7 @@ SFP_SW_CONTROL = 1
 SFP_FW_CONTROL = 0
 
 CMIS_MAX_POWER_OFFSET = 201
+CMIS_MEDIA_INTERFACE_TECH_OFFSET = 212
 
 SFF_POWER_CLASS_MASK = 0xE3
 SFF_POWER_CLASS_MAPPING = {
@@ -1051,6 +1052,16 @@ class SFP(NvidiaSFPCommon):
         """
         return isinstance(xcvr_api, sff8636.Sff8636Api) or isinstance(xcvr_api, sff8436.Sff8436Api)
 
+    def check_media_interface_technology(self, xcvr_api):
+        """Check media interface technology
+        0x0F in offset 212, means the module is 'Copper cable, linear active equalizers'.
+        Nvidia doesn't support it to be SW control, so we set it to FW control
+        Args:
+            xcvr_api (object): xcvr api object
+        """
+        media_interface = self.read_eeprom(CMIS_MEDIA_INTERFACE_TECH_OFFSET, 1)
+        return media_interface[0] == 0x0F if media_interface else False
+
     def is_supported_for_software_control(self, xcvr_api):
         """Check if the api object supports software control
 
@@ -1063,15 +1074,10 @@ class SFP(NvidiaSFPCommon):
         if xcvr_api.is_flat_memory():
             if self.is_cmis_api(xcvr_api):
                 # For Copper active modules, Nvidia doesn't support SW control
-                if xcvr_api.get_media_interface_technology() == 'Copper cable, linear active equalizers':
-                    return False
-                return True
-            elif self.is_sff_api(xcvr_api):
-                return True
-            else:
-                return False
-        else:
-            return self.is_cmis_api(xcvr_api)
+                return self.check_media_interface_technology(xcvr_api)
+            return self.is_sff_api(xcvr_api)
+
+        return self.is_cmis_api(xcvr_api)
 
     def check_power_capability(self):
         """Check module max power with cage power limit

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -1061,10 +1061,15 @@ class SFP(NvidiaSFPCommon):
             bool: True if the api object supports software control
         """
         if xcvr_api.is_flat_memory():
-            # For Copper active modules, Nvidia doesn't support SW control
-            if xcvr_api.get_media_interface_technology() == 'Copper cable, linear active equalizers':
+            if self.is_cmis_api(xcvr_api):
+                # For Copper active modules, Nvidia doesn't support SW control
+                if xcvr_api.get_media_interface_technology() == 'Copper cable, linear active equalizers':
+                    return False
+                return True
+            elif self.is_sff_api(xcvr_api):
+                return True
+            else:
                 return False
-            return self.is_cmis_api(xcvr_api) or self.is_sff_api(xcvr_api)
         else:
             return self.is_cmis_api(xcvr_api)
 


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Nvidia doesn't support Copper Active modules to be SW control.
In case we use this kind of module, it should be classified as FW control. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Checked the media interface technology for the module. If it is Copper cable, linear active equalizers, it should be classified as FW control. 
#### How to verify it
Run this code on Mellanox switch with Copper cable, linear active equalizers module. check control sysfs to make sure it is classified as FW control. (control = 0).
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
202412
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)