### PR TITLE
[Mellanox] Update sensors.conf for SN5640, SN5610N

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5610n-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn5610n-r0/sensors.conf
@@ -1,14 +1,8 @@
 ##################################################################################
-# Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
-# Platform specific sensors config for SN5640
+# Platform specific sensors config for SN5610N
 ##################################################################################
-
-# Hardware revision default
-
-# ASIC temperature sensor
-chip "mlxsw-i2c-*-48"
-    label temp1 "Ambient ASIC Temp"
 
 # Fan and port ambient temperature sensors
 chip "tmp102-i2c-*-49"
@@ -363,8 +357,8 @@ chip "mp2891-i2c-*-6e"
     label power2   "PMIC-11 VDDSCC Rail Pwr (out1)"
     label power3   "PMIC-11 DVDD_M Rail Pwr (out2)"
     label curr1    "PMIC-11 13V5 VDDSCC DVDD_M Rail Curr (in1)"
-    label curr2    "PMIC-11 VDDSCC Rail Curr (out1)"
-    label curr3    "PMIC-11 DVDD_M Rail Curr (out2)"
+    label curr2    "PMIC-11 DVDD_M Rail Curr (out1)"
+    label curr3    "PMIC-11 VDDSCC Rail Curr (out2)"
     ignore curr4
     ignore curr5
     ignore curr6
@@ -378,8 +372,8 @@ chip "xdpe1a2g7-i2c-*-6e"
     label power2   "PMIC-11 VDDSCC Rail Pwr (out1)"
     label power3   "PMIC-11 DVDD_M Rail Pwr (out2)"
     label curr1    "PMIC-11 13V5 VDDSCC DVDD_M Rail Curr (in1)"
-    label curr2    "PMIC-11 VDDSCC Rail Curr (out1)"
-    label curr3    "PMIC-11 DVDD_M Rail Curr (out2)"
+    label curr2    "PMIC-11 DVDD_M Rail Curr (out1)"
+    label curr3    "PMIC-11 VDDSCC Rail Curr (out2)"
     ignore curr4
     ignore curr5
     ignore curr6

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/sensors.conf
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/sensors.conf
@@ -1,14 +1,8 @@
 ##################################################################################
-# Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Platform specific sensors config for SN5640
 ##################################################################################
-
-# Hardware revision default
-
-# ASIC temperature sensor
-chip "mlxsw-i2c-*-48"
-    label temp1 "Ambient ASIC Temp"
 
 # Fan and port ambient temperature sensors
 chip "tmp102-i2c-*-49"
@@ -363,8 +357,8 @@ chip "mp2891-i2c-*-6e"
     label power2   "PMIC-11 VDDSCC Rail Pwr (out1)"
     label power3   "PMIC-11 DVDD_M Rail Pwr (out2)"
     label curr1    "PMIC-11 13V5 VDDSCC DVDD_M Rail Curr (in1)"
-    label curr2    "PMIC-11 VDDSCC Rail Curr (out1)"
-    label curr3    "PMIC-11 DVDD_M Rail Curr (out2)"
+    label curr2    "PMIC-11 DVDD_M Rail Curr (out1)"
+    label curr3    "PMIC-11 VDDSCC Rail Curr (out2)"
     ignore curr4
     ignore curr5
     ignore curr6
@@ -378,8 +372,8 @@ chip "xdpe1a2g7-i2c-*-6e"
     label power2   "PMIC-11 VDDSCC Rail Pwr (out1)"
     label power3   "PMIC-11 DVDD_M Rail Pwr (out2)"
     label curr1    "PMIC-11 13V5 VDDSCC DVDD_M Rail Curr (in1)"
-    label curr2    "PMIC-11 VDDSCC Rail Curr (out1)"
-    label curr3    "PMIC-11 DVDD_M Rail Curr (out2)"
+    label curr2    "PMIC-11 DVDD_M Rail Curr (out1)"
+    label curr3    "PMIC-11 VDDSCC Rail Curr (out2)"
     ignore curr4
     ignore curr5
     ignore curr6


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To have the updated sensors.conf file

#### How I did it
Updated sensors.conf for SN5640, SN5610N
#### How to verify it
Install image on Mellanox SN5640/SN5610N and make sure the right file is there
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

