### PR TITLE
[Mellanox] Update SN5640 and SN5600 SKUs buffers to disable egress_mirroring

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/buffers_defaults_t0.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '144129024' %}
+{% set ingress_lossless_pool_size =  '145321984' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '158229504' %}
-{% set egress_lossy_pool_size =  '144129024' %}
+{% set egress_lossy_pool_size =  '145321984' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/buffers_defaults_t1.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '144129024' %}
+{% set ingress_lossless_pool_size =  '145321984' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '158229504' %}
-{% set egress_lossy_pool_size =  '144129024' %}
+{% set egress_lossy_pool_size =  '145321984' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_t0.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '142703616' %}
+{% set ingress_lossless_pool_size =  '144019456' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '158229504' %}
-{% set egress_lossy_pool_size =  '142703616' %}
+{% set egress_lossy_pool_size =  '144019456' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_t1.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '142703616' %}
+{% set ingress_lossless_pool_size =  '144019456' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '158229504' %}
-{% set egress_lossy_pool_size =  '142703616' %}
+{% set egress_lossy_pool_size =  '144019456' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/buffers_defaults_t0.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '108270592' %}
+{% set ingress_lossless_pool_size =  '110656512' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '136209408' %}
-{% set egress_lossy_pool_size =  '108270592' %}
+{% set egress_lossy_pool_size =  '110656512' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/buffers_defaults_t1.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '108270592' %}
+{% set ingress_lossless_pool_size =  '110656512' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '136209408' %}
-{% set egress_lossy_pool_size =  '108270592' %}
+{% set egress_lossy_pool_size =  '110656512' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/buffers_defaults_t0.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '105419776' %}
+{% set ingress_lossless_pool_size =  '108051456' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '136209408' %}
-{% set egress_lossy_pool_size =  '105419776' %}
+{% set egress_lossy_pool_size =  '108051456' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/buffers_defaults_t1.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '105419776' %}
+{% set ingress_lossless_pool_size =  '108051456' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '136209408' %}
-{% set egress_lossy_pool_size =  '105419776' %}
+{% set egress_lossy_pool_size =  '108051456' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to enlarge buffers size for SPC4 & SPC5 SKUs, I disabled egress mirroring and updated calculations. 


#### How I did it
Updated buffer_defaults_t0.j2, buffer_defaults_t1.j2 for SPC4, SPC5 specific SKUs.
#### How to verify it
take SDK dump and check 'Shared Buffers DB Dump'.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

